### PR TITLE
Fix code formatting with gofmt and goimports

### DIFF
--- a/abs/replica_client.go
+++ b/abs/replica_client.go
@@ -11,10 +11,11 @@ import (
 	"time"
 
 	"github.com/Azure/azure-storage-blob-go/azblob"
-	"github.com/benbjohnson/litestream"
-	"github.com/benbjohnson/litestream/internal"
 	"github.com/superfly/ltx"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/internal"
 )
 
 // ReplicaClientType is the client type for this package.

--- a/cmd/litestream/main.go
+++ b/cmd/litestream/main.go
@@ -16,6 +16,10 @@ import (
 	"time"
 
 	"filippo.io/age"
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/superfly/ltx"
+	"gopkg.in/yaml.v2"
+
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/abs"
 	"github.com/benbjohnson/litestream/file"
@@ -23,9 +27,6 @@ import (
 	"github.com/benbjohnson/litestream/internal"
 	"github.com/benbjohnson/litestream/s3"
 	"github.com/benbjohnson/litestream/sftp"
-	_ "github.com/mattn/go-sqlite3"
-	"github.com/superfly/ltx"
-	"gopkg.in/yaml.v2"
 )
 
 // Build information.

--- a/cmd/litestream/replicate.go
+++ b/cmd/litestream/replicate.go
@@ -11,14 +11,15 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/mattn/go-shellwords"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/abs"
 	"github.com/benbjohnson/litestream/file"
 	"github.com/benbjohnson/litestream/gcs"
 	"github.com/benbjohnson/litestream/s3"
 	"github.com/benbjohnson/litestream/sftp"
-	"github.com/mattn/go-shellwords"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
 // ReplicateCommand represents a command that continuously replicates SQLite databases.

--- a/db.go
+++ b/db.go
@@ -17,10 +17,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/benbjohnson/litestream/internal"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream/internal"
 )
 
 // Default DB settings.

--- a/db_test.go
+++ b/db_test.go
@@ -12,9 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/superfly/ltx"
+
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/internal"
-	"github.com/superfly/ltx"
 )
 
 var logLevel = flag.String("log.level", "debug", "")

--- a/file/replica_client.go
+++ b/file/replica_client.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/superfly/ltx"
+
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/internal"
-	"github.com/superfly/ltx"
 )
 
 // ReplicaClientType is the client type for this package.

--- a/gcs/replica_client.go
+++ b/gcs/replica_client.go
@@ -10,10 +10,11 @@ import (
 	"time"
 
 	"cloud.google.com/go/storage"
-	"github.com/benbjohnson/litestream"
-	"github.com/benbjohnson/litestream/internal"
 	"github.com/superfly/ltx"
 	"google.golang.org/api/iterator"
+
+	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/internal"
 )
 
 // ReplicaClientType is the client type for this package.

--- a/litestream_test.go
+++ b/litestream_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/benbjohnson/litestream"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream"
 )
 
 func TestChecksum(t *testing.T) {

--- a/mock/replica_client.go
+++ b/mock/replica_client.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"io"
 
-	"github.com/benbjohnson/litestream"
 	"github.com/superfly/ltx"
+
+	"github.com/benbjohnson/litestream"
 )
 
 var _ litestream.ReplicaClient = (*ReplicaClient)(nil)

--- a/replica_client_test.go
+++ b/replica_client_test.go
@@ -12,13 +12,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/superfly/ltx"
+
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/abs"
 	"github.com/benbjohnson/litestream/file"
 	"github.com/benbjohnson/litestream/gcs"
 	"github.com/benbjohnson/litestream/s3"
 	"github.com/benbjohnson/litestream/sftp"
-	"github.com/superfly/ltx"
 )
 
 var (

--- a/replica_test.go
+++ b/replica_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/superfly/ltx"
+
 	"github.com/benbjohnson/litestream"
 	"github.com/benbjohnson/litestream/file"
 	"github.com/benbjohnson/litestream/mock"
-	"github.com/superfly/ltx"
 )
 
 func TestReplica_Sync(t *testing.T) {

--- a/s3/replica_client.go
+++ b/s3/replica_client.go
@@ -19,10 +19,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/benbjohnson/litestream"
-	"github.com/benbjohnson/litestream/internal"
 	"github.com/superfly/ltx"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/internal"
 )
 
 // ReplicaClientType is the client type for this package.

--- a/sftp/replica_client.go
+++ b/sftp/replica_client.go
@@ -11,11 +11,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/benbjohnson/litestream"
-	"github.com/benbjohnson/litestream/internal"
 	"github.com/pkg/sftp"
 	"github.com/superfly/ltx"
 	"golang.org/x/crypto/ssh"
+
+	"github.com/benbjohnson/litestream"
+	"github.com/benbjohnson/litestream/internal"
 )
 
 // ReplicaClientType is the client type for this package.


### PR DESCRIPTION
## Summary
- Run `gofmt` on all Go files for consistent formatting
- Run `goimports -local github.com/benbjohnson/litestream` to properly group imports
- Separate standard library, external, and local imports according to Go conventions

## Purpose
This PR brings the codebase into compliance with Go formatting standards and makes future PRs cleaner by avoiding import order changes mixed with actual code changes.

## Changes
All changes are formatting-only:
- Import statements are now properly grouped and ordered
- No functional changes to any code

## Test plan
- [x] All tests pass
- [x] `go vet ./...` passes
- [x] `staticcheck ./...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)